### PR TITLE
fix: use css media query instead of react-responsive

### DIFF
--- a/website/package.json
+++ b/website/package.json
@@ -30,7 +30,6 @@
     "clsx": "^1.1.1",
     "react": "^17.0.1",
     "react-dom": "^17.0.1",
-    "react-responsive": "^9.0.0-beta.6",
     "three": "^0.137.4"
   }
 }

--- a/website/src/components/ModelDownloadButtonGroup.js
+++ b/website/src/components/ModelDownloadButtonGroup.js
@@ -1,7 +1,7 @@
 import useBaseUrl from '@docusaurus/useBaseUrl'
 import React from 'react'
-import { useMediaQuery } from 'react-responsive'
 import { DownloadLink } from './DownloadButton'
+import styles from './ModelDownloadButtonGroup.module.css'
 
 const MODEL_LIST = [
   { label: 'FBX', path: '/model/toiocorecube_v003.fbx' },
@@ -12,9 +12,16 @@ const MODEL_LIST = [
 ]
 
 export const ModelDownloadButtonGroup = () => {
-  const isNarrow = useMediaQuery({ query: '(max-width: 1130px)' })
-
-  return isNarrow ? <DropDownButtonGroup /> : <SimpleButtonGroup />
+  return (
+    <>
+      <div className={styles.buttonGroupDropdown}>
+        <DropDownButtonGroup />
+      </div>
+      <div className={styles.buttonGroupSimple}>
+        <SimpleButtonGroup />
+      </div>
+    </>
+  )
 }
 
 const SimpleButtonGroup = () => {

--- a/website/src/components/ModelDownloadButtonGroup.module.css
+++ b/website/src/components/ModelDownloadButtonGroup.module.css
@@ -1,0 +1,17 @@
+.buttonGroupSimple {
+  display: block;
+}
+
+.buttonGroupDropdown {
+  display: none;
+}
+
+@media screen and (max-width: 1130px) {
+  .buttonGroupSimple {
+    display: none;
+  }
+
+  .buttonGroupDropdown {
+    display: block;
+  }
+}


### PR DESCRIPTION
リロードしたときのdomの状態が想定と異なるものになっていました．
mdxを静的ビルドした段階で一部memo化されてしまっているような挙動．

根本原因はわからずですが，とりあえずjsでレスポンシブの判定をするのをやめ，cssのmedia queryを使うようにしました．

