### PR TITLE
fix: use ResizeObserver polyfill to support old browser

### DIFF
--- a/website/package.json
+++ b/website/package.json
@@ -24,6 +24,7 @@
   "dependencies": {
     "@docusaurus/core": "2.0.0-beta.6",
     "@docusaurus/preset-classic": "2.0.0-beta.6",
+    "@juggle/resize-observer": "^3.3.1",
     "@react-three/drei": "^8.7.4",
     "@react-three/fiber": "^7.0.25",
     "buffer": "^6.0.3",

--- a/website/src/components/Cube3DView.js
+++ b/website/src/components/Cube3DView.js
@@ -1,4 +1,5 @@
 import BrowserOnly from '@docusaurus/BrowserOnly'
+import { ResizeObserver } from '@juggle/resize-observer'
 import { ContactShadows, Environment, OrbitControls, PerspectiveCamera } from '@react-three/drei'
 import { Canvas } from '@react-three/fiber'
 import React, { Suspense } from 'react'
@@ -11,7 +12,7 @@ export const Cube3DView = () => {
     <BrowserOnly fallback={null}>
       {() => {
         return (
-          <Canvas shadows>
+          <Canvas shadows resize={{ polyfill: ResizeObserver }}>
             <color attach="background" args={['#999']} />
             <Suspense fallback={null}>
               <CubeModel />

--- a/website/src/components/HeroCubeView.js
+++ b/website/src/components/HeroCubeView.js
@@ -1,4 +1,5 @@
 import BrowserOnly from '@docusaurus/BrowserOnly'
+import { ResizeObserver } from '@juggle/resize-observer'
 import {
   ContactShadows,
   Environment,
@@ -42,7 +43,7 @@ export const HeroCubeView = () => {
       {() => {
         return (
           <Suspense fallback={null}>
-            <Canvas shadows>
+            <Canvas shadows resize={{ polyfill: ResizeObserver }}>
               <Environment preset="city" />
               <PerspectiveCamera makeDefault position={[0, 0, 0.08]} near={0.01} />
               <ambientLight intensity={intensity / 3} />


### PR DESCRIPTION
iOS 12のSafariなど古いブラウザにおいてResizeObserverが使えず，ページが真っ白になってしまう問題の修正．
