### PR TITLE
fix: correct broken links

### DIFF
--- a/docs/how_to_update_cube.md
+++ b/docs/how_to_update_cube.md
@@ -37,7 +37,7 @@ original_id: how_to_update_cube
 
 ### 2022/04/27 <span class="new"/>
 
-キューブの[3D データ](hardware_shape.md#3d-データ)と[マウント形状](hardware_shape.md#マウント形状)を公開しました。
+キューブの[3D データ](hardware_shape.mdx#3d-データ)と[マウント形状](hardware_shape.mdx#マウント形状)を公開しました。
 
 ### 2021/07/19
 

--- a/website/i18n/en/docusaurus-plugin-content-docs/version-2.3.0/how_to_update_cube.md
+++ b/website/i18n/en/docusaurus-plugin-content-docs/version-2.3.0/how_to_update_cube.md
@@ -36,7 +36,7 @@ For the version displayed, any feature that has changed since the previous versi
 
 ### 2022/04/27 <span class="new"/>
 
-Added cube's [3D model data](hardware_shape.md#3d-model) and information about [shapes of block attachment](hardware_shape.md#protruding-shapes-for-block-attachment).
+Added cube's [3D model data](hardware_shape.mdx#3d-model) and information about [shapes of block attachment](hardware_shape.mdx#protruding-shapes-for-block-attachment).
 
 ### 2021/07/19
 

--- a/website/versioned_docs/version-2.3.0/how_to_update_cube.md
+++ b/website/versioned_docs/version-2.3.0/how_to_update_cube.md
@@ -37,7 +37,7 @@ original_id: how_to_update_cube
 
 ### 2022/04/27 <span class="new"/>
 
-キューブの[3D データ](hardware_shape.md#3d-データ)と[マウント形状](hardware_shape.md#マウント形状)を公開しました。
+キューブの[3D データ](hardware_shape.mdx#3d-データ)と[マウント形状](hardware_shape.mdx#マウント形状)を公開しました。
 
 ### 2021/07/19
 


### PR DESCRIPTION
[アップデート内容](https://toio.github.io/toio-spec/docs/how_to_update_cube#20220427-)の各ページへのリンクが切れているのを修正